### PR TITLE
Add Flask service to Docker Compose and improve Kafka integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,13 @@ services:
         KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
     ports:
       - "8081:8080"
+      
+  flask:
+    build: ./flask
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./raw_data:/raw_data
 
   namenode:
     image: bde2020/hadoop-namenode:2.0.0-hadoop3.2.1-java8

--- a/flask/app.py
+++ b/flask/app.py
@@ -5,7 +5,7 @@ from kafka_producer import send_to_kafka, initialize_kafka_producer
 app = Flask(__name__)
 
 # Load Parquet data
-DATA_PATH = "../raw_data/neo-bank-non-sub-churn-prediction/test.parquet"  # TODO: integrate docker compose via volume
+DATA_PATH = "../raw_data/neo-bank-non-sub-churn-prediction/test.parquet" 
 
 # Load data
 df = pd.read_parquet(DATA_PATH)

--- a/flask/app.py
+++ b/flask/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template, request, jsonify
 import pandas as pd
-from kafka_producer import send_to_kafka
+from kafka_producer import send_to_kafka, initialize_kafka_producer
 
 app = Flask(__name__)
 
@@ -64,6 +64,16 @@ def upload_data():
         return jsonify({"message": f"Data up to {selected_date} uploaded successfully!"})
     else:
         return jsonify({"error": "Request must be JSON"}), 400
+
+@app.route('/check_kafka', methods=['GET'])
+def check_kafka():
+    global kafka_connected
+    if initialize_kafka_producer():
+        kafka_connected = True
+        return jsonify({"message": "Kafka connection successful!", "status": "connected"})
+    else:
+        kafka_connected = False
+        return jsonify({"error": "Failed to connect to Kafka", "status": "disconnected"}), 500
 
 
 if __name__ == '__main__':

--- a/flask/app.py
+++ b/flask/app.py
@@ -12,7 +12,7 @@ df = pd.read_parquet(DATA_PATH)
 df['date'] = pd.to_datetime(df['date'])
 
 # Global variable to track the latest uploaded date
-latest_uploaded_date = '1999-01-01'
+latest_uploaded_date = None
 
 # Convert DataFrame to a summary grouped by date
 def get_data_summary(year, month):
@@ -23,7 +23,12 @@ def get_data_summary(year, month):
         .reset_index(name='count')
     )
     summary['date'] = pd.to_datetime(summary['date'])
-    summary['is_uploaded'] = summary['date'].apply(lambda x: x <= pd.to_datetime(latest_uploaded_date))
+
+    if latest_uploaded_date is None:
+        summary['is_uploaded'] = False
+    else:
+        summary['is_uploaded'] = summary['date'] <= pd.to_datetime(latest_uploaded_date)
+
     summary['date'] = summary['date'].apply(lambda x: x.strftime('%Y-%m-%d'))  # Format date here
     return summary.to_dict(orient='records')
 

--- a/flask/kafka_producer.py
+++ b/flask/kafka_producer.py
@@ -4,7 +4,7 @@ from datetime import date
 from kafka.errors import NoBrokersAvailable
 
 KAFKA_TOPIC = "neo_bank_data"
-KAFKA_BROKER = "localhost:9092"
+KAFKA_BROKER = "kafka:9093"
 
 producer = None
 

--- a/flask/kafka_producer.py
+++ b/flask/kafka_producer.py
@@ -1,16 +1,27 @@
 from kafka import KafkaProducer
 import json
 from datetime import date
+from kafka.errors import NoBrokersAvailable
 
 KAFKA_TOPIC = "neo_bank_data"
 KAFKA_BROKER = "localhost:9092"
 
-producer = KafkaProducer(
-    bootstrap_servers=KAFKA_BROKER,
-    value_serializer=lambda v: json.dumps(v, default=str).encode('utf-8')  
-)
+producer = None
+
+def initialize_kafka_producer():
+    global producer
+    try:
+        producer = KafkaProducer(
+            bootstrap_servers=KAFKA_BROKER,
+            value_serializer=lambda v: json.dumps(v, default=str).encode('utf-8')
+        )
+        return True
+    except NoBrokersAvailable:
+        return False
 
 def send_to_kafka(data):
+    if producer is None:
+        raise Exception("Kafka producer is not initialized")
     data = {k: (v.isoformat() if isinstance(v, date) else v) for k, v in data.items()}
     producer.send(KAFKA_TOPIC, data)
     producer.flush()

--- a/flask/static/styles.css
+++ b/flask/static/styles.css
@@ -85,3 +85,15 @@ tr:nth-child(even) {
 .action-btn:hover {
     background-color: #007B9A;
 }
+
+.status-bar {
+    display: flex;
+    justify-content: space-between; 
+    align-items: center; 
+}
+
+.kafka-left {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}

--- a/flask/templates/index.html
+++ b/flask/templates/index.html
@@ -14,10 +14,15 @@
     </header>
 
     <div class="container">
-        <div style="display: inline-flex; align-items: center; gap: 20px;">
-            <p id="kafka-status">Kafka Status: Checking...</p>
-            <button onclick="checkKafka()">Check Kafka Connection</button>
-        </div>    
+        <div class="status-bar">
+            <div class="kafka-left">
+                <p id="kafka-status">Kafka Status: Checking...</p>
+                <button onclick="checkKafka()">Check Kafka Connection</button>
+            </div>
+            <div>
+                Latest Uploaded Date: <span id="latest-date">Not yet uploaded</span>
+            </div>
+        </div>   
         <div>
             <label for="year">Select Year:</label>
             <select id="year">
@@ -127,6 +132,7 @@
                     success: function(response) {
                         alert(response.message);
                         fetchData();
+                        $('#latest-date').text(date);
                     },
                     error: function(xhr, status, error) {
                         alert("Error uploading data: " + xhr.responseText);

--- a/flask/templates/index.html
+++ b/flask/templates/index.html
@@ -14,6 +14,10 @@
     </header>
 
     <div class="container">
+        <div style="display: inline-flex; align-items: center; gap: 20px;">
+            <p id="kafka-status">Kafka Status: Checking...</p>
+            <button onclick="checkKafka()">Check Kafka Connection</button>
+        </div>    
         <div>
             <label for="year">Select Year:</label>
             <select id="year">
@@ -61,6 +65,24 @@
     </div>
 
     <script>
+        function checkKafka() {
+            fetch('/check_kafka')
+                .then(response => response.json())
+                .then(data => {
+                    const statusElement = document.getElementById('kafka-status');
+                    if (data.status === "connected") {
+                        statusElement.textContent = "Kafka Status: Connected";
+                        statusElement.style.color = "green";
+                    } else {
+                        statusElement.textContent = "Kafka Status: Disconnected";
+                        statusElement.style.color = "red";
+                    }
+                })
+                .catch(error => {
+                    console.error('Error checking Kafka connection:', error);
+                });
+        }
+
         function fetchData() {
             let year = $('#year').val();
             let month = $('#month').val();


### PR DESCRIPTION
- Added Flask service to `docker-compose.yml` with port `5000` and `raw_data` volume.
- Updated Kafka broker address to `kafka:9093` and added Kafka connection check endpoint (`/check_kafka`).
- Enhanced frontend with Kafka status bar and latest uploaded date display.
- Refactored `latest_uploaded_date` logic and improved error handling for Kafka producer.

These changes improve Kafka integration and provide better system visibility.