### PR TITLE
Integrate Kafka Connect with HDFS Sink and Avro Schema Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 **/.ipynb_checkpoints/
 
 *.parquet
+
+/documents/notes/

--- a/airflow/dags/manage_hdfs.py
+++ b/airflow/dags/manage_hdfs.py
@@ -19,5 +19,5 @@ with DAG(
     create_user_hdfs_dir = PythonOperator(
         task_id='create_user_hdfs_dir',
         python_callable=create_and_manage_user_hdfs_directory,
-        op_kwargs={'username': 'spark', 'folder': 'test'},  
+        op_kwargs={'username': 'appuser', 'folder': 'neo_bank_data'},  
     )

--- a/airflow/dags/tasks/hdfs_user_operations.py
+++ b/airflow/dags/tasks/hdfs_user_operations.py
@@ -23,7 +23,7 @@ def create_and_manage_user_hdfs_directory(username: str, folder: str, proxy_user
         print(f"Directory already exists: {folder_path}")
 
     parts = folder_path.split('/')
-    paths = ['/'.join(parts[:i+1]) for i in range(1, len(parts))]
+    paths = ['/'.join(parts[:i+1]) for i in range(2, len(parts))]
 
     for path in paths:
         hdfs_client.set_owner(path, owner=username, group="supergroup")

--- a/airflow/dags/test/read_hdfs_sink.py
+++ b/airflow/dags/test/read_hdfs_sink.py
@@ -1,0 +1,53 @@
+from airflow import DAG
+from airflow.providers.apache.hdfs.hooks.webhdfs import WebHDFSHook
+from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
+from datetime import timedelta
+import pyarrow.parquet as pq
+import pandas as pd
+from io import BytesIO
+
+# Function to read the Parquet file and display a sample
+def read_parquet_sample(**kwargs):
+    # Define the file path on HDFS
+    file_path = "/user/appuser/neo_bank_data/neo_bank_data/partition=0/neo_bank_data+0+0000001900+0000001999.parquet"
+    
+    # Initialize WebHDFSHook with the appropriate connection ID
+    hdfs_hook = WebHDFSHook(webhdfs_conn_id="hdfs_default", proxy_user="appuser")
+    
+    # Read the Parquet file from HDFS using WebHDFSHook
+    file_data = hdfs_hook.read_file(file_path)
+    
+    # Convert the file content to a Pandas DataFrame
+    with BytesIO(file_data) as file_stream:
+        # Use PyArrow to read the Parquet file
+        table = pq.read_table(file_stream)
+        df = table.to_pandas()
+        
+        # Display a sample (first 5 rows)
+        print("Sample Data:")
+        print(df.head(1).T)  # Display the first 5 rows
+
+# Define the default arguments for the DAG
+default_args = {
+    'owner': 'airflow',
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+}
+
+# Define the DAG
+with DAG(
+    'read_parquet_sample',
+    default_args=default_args,
+    description='A simple DAG to read and display a sample from a Parquet file in HDFS',
+    schedule_interval=None,  # Manual trigger
+    start_date=days_ago(1),
+    catchup=False,
+) as dag:
+
+    # Task to read and display a sample from the Parquet file
+    read_sample_task = PythonOperator(
+        task_id='read_parquet_sample',
+        python_callable=read_parquet_sample,
+        provide_context=True
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,10 @@ services:
       - -c
       - |
         confluent-hub install --no-prompt confluentinc/kafka-connect-hdfs:latest
-        /etc/confluent/docker/run
+        /etc/confluent/docker/run &
+        sleep 10
+        curl -X POST -H "Content-Type: application/json" --data @/hdfs-sink-config/hdfs-sink.json http://localhost:8083/connectors
+        wait
 
   flask:
     build: ./flask

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     container_name: kafka-connect
     depends_on:
       - kafka
+      - schema-registry
     environment:
       CONNECT_BOOTSTRAP_SERVERS: "kafka:9093"
       CONNECT_REST_ADVERTISED_HOST_NAME: "kafka-connect"
@@ -58,9 +59,10 @@ services:
       CONNECT_CONFIG_STORAGE_TOPIC: "connect-configs"
       CONNECT_OFFSET_STORAGE_TOPIC: "connect-offsets"
       CONNECT_STATUS_STORAGE_TOPIC: "connect-status"
-      CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
-      CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
-      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
+      CONNECT_KEY_CONVERTER: "io.confluent.connect.avro.AvroConverter"
+      CONNECT_VALUE_CONVERTER: "io.confluent.connect.avro.AvroConverter"
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8082"
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8082"
       CONNECT_PLUGIN_PATH: "/usr/share/confluent-hub-components"
       CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: "1"
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,33 @@ services:
     ports:
       - "8081:8080"
       
+  kafka-connect:
+    image: confluentinc/cp-kafka-connect:7.8.0
+    container_name: kafka-connect
+    depends_on:
+      - kafka
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: "kafka:9093"
+      CONNECT_REST_ADVERTISED_HOST_NAME: "kafka-connect"
+      CONNECT_GROUP_ID: "connect-cluster"
+      CONNECT_CONFIG_STORAGE_TOPIC: "connect-configs"
+      CONNECT_OFFSET_STORAGE_TOPIC: "connect-offsets"
+      CONNECT_STATUS_STORAGE_TOPIC: "connect-status"
+      CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
+      CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
+      CONNECT_PLUGIN_PATH: "/usr/share/confluent-hub-components"
+    volumes:
+      - ./kafka/hdfs-sink-config:/hdfs-sink-config
+    ports:
+      - "8083:8083"
+    command:
+      - bash
+      - -c
+      - |
+        confluent-hub install --no-prompt confluentinc/kafka-connect-hdfs:latest
+        /etc/confluent/docker/run
+
   flask:
     build: ./flask
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - |
         confluent-hub install --no-prompt confluentinc/kafka-connect-hdfs:latest
         /etc/confluent/docker/run &
-        sleep 10
+        sleep 30
         curl -X POST -H "Content-Type: application/json" --data @/hdfs-sink-config/hdfs-sink.json http://localhost:8083/connectors
         wait
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
       CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
       CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
       CONNECT_PLUGIN_PATH: "/usr/share/confluent-hub-components"
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: "1"
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "1"
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: "1"
     volumes:
       - ./kafka/hdfs-sink-config:/hdfs-sink-config
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,18 @@ services:
     ports:
       - "8081:8080"
       
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.8.0
+    container_name: schema-registry
+    depends_on:
+      - kafka
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "kafka:9093"
+      SCHEMA_REGISTRY_HOST_NAME: "schema-registry"
+      SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8082"
+    ports:
+      - "8082:8082"
+
   kafka-connect:
     image: confluentinc/cp-kafka-connect:7.8.0
     container_name: kafka-connect

--- a/documents/commands.md
+++ b/documents/commands.md
@@ -1,50 +1,131 @@
-# 커맨드 목록
+# **커맨드 목록**  
 
 ---
 
-### **가상 환경 설정**
+## **가상 환경 설정**  
 - `python -m venv venv`  
-  Python 가상 환경을 생성
-  
+  Python 가상 환경을 생성  
 - `venv\Scripts\activate`  
-  Windows에서 가상 환경을 활성화
+  Windows에서 가상 환경을 활성화  
 
 ---
 
-### **Docker 관련 명령어**
-
-- `docker exec data-analysis-kafka-1 kafka-topics --list --bootstrap-server localhost:9092`  
-  Kafka의 토픽 목록을 조회
-
-- `docker exec -it data-analysis-postgres-1 psql -U user -d mydb`  
-  Docker 컨테이너 내의 PostgreSQL에 접속
+## **Docker 관련 명령어**  
 
 - `docker compose -f docker-compose.light.yml up -d`  
-  Docker Compose를 사용하여 컨테이너들을 백그라운드에서 실행
+  Docker Compose를 사용하여 컨테이너들을 백그라운드에서 실행  
+
+- `docker build --tag airflow-custom:v4 airflow/`  
+  `airflow/` 디렉토리를 기반으로 `airflow-custom:v4` 태그를 가진 Docker 이미지 빌드  
+
+- `docker exec data-analysis-kafka-1 kafka-topics --list --bootstrap-server localhost:9092`  
+  Kafka의 토픽 목록을 조회  
+
+- `docker exec -it data-analysis-postgres-1 psql -U user -d mydb`  
+  Docker 컨테이너 내의 PostgreSQL에 접속  
+
+- `docker exec -it kafka kafka-console-producer \`  
+  `--topic hdfs_pipeline \`  
+  `--bootstrap-server kafka:9092`  
+  Kafka 프로듀서를 실행하여 `hdfs_pipeline` 토픽으로 메시지를 보냄  
+
+- `docker exec -it -u root spark-master /bin/bash`  
+  Spark Master 컨테이너에 root 사용자로 접속  
+
+- `docker exec -it -u root airflow-webserver /bin/bash`  
+  Airflow Webserver 컨테이너에 root 사용자로 접속  
+
+- `docker exec -it -u root airflow-scheduler /bin/bash`  
+  Airflow Scheduler 컨테이너에 root 사용자로 접속  
+
+- `docker cp <hostpath> <container>:<path>`  
+  호스트에서 Docker 컨테이너로 파일을 복사  
+
+- `docker inspect <container_id>`  
+  특정 컨테이너의 상세 정보를 조회  
 
 ---
 
-### **네트워크 관련 명령어**
+## **PostgreSQL 명령어**  
+
+- `psql -U admin -d postgres`  
+  PostgreSQL에 `admin` 사용자로 접속  
+
+- `\dt`  
+  PostgreSQL에서 현재 데이터베이스의 테이블 목록 조회  
+
+---
+
+## **네트워크 관련 명령어**  
 
 - `netstat -ano | findstr :5432`  
-  5432 포트로 연결된 프로세스 반환
+  5432 포트로 연결된 프로세스 반환  
+
+- `ping spark-master`  
+  `spark-master` 노드에 대한 네트워크 연결 확인  
 
 ---
 
-### **Git 명령어**
+## **Git 명령어**  
 
 - `git diff kafka/docker-compose.light.yml >> diff.txt`  
-  특정 파일의 변경 내용을 `diff.txt`에 저장
+  특정 파일의 변경 내용을 `diff.txt`에 저장  
+
+- `git diff --cached`  
+  Staging된 변경 사항을 확인  
+
+- `git diff branch1..branch2`  
+  `branch1`과 `branch2`의 차이점 비교  
 
 - `git reset HEAD~1`  
-  마지막 커밋 복구
+  마지막 커밋 복구  
 
 - `git add -p docker-compose.yml`  
-  `docker-compose.yml` 파일의 부분 변경 사항만 선택적으로 staging 
+  `docker-compose.yml` 파일의 부분 변경 사항만 선택적으로 staging  
+
+- `git checkout -b NEW_BRANCH_NAME COMMIT_ID`  
+  특정 커밋 ID에서 새로운 브랜치를 생성하고 이동  
+
+- `git clone -b issue-report https://github.com/yehoon17/data-analysis.git`  
+  `issue-report` 브랜치를 기준으로 `data-analysis` 저장소 클론  
+
+- `git stash push --staged -m "new line and custom docker image version"`  
+  Staging된 변경 사항을 stash에 저장  
+
+- `git log --follow -- <filename>`  
+  특정 파일의 변경 이력을 추적  
 
 ---
 
-### **Python 패키지 관리**
+## **Python 및 Spark 관련 명령어**  
 
 - `pip freeze >> requirements.txt`  
-  현재 가상 환경에 설치된 패키지 목록을 `requirements.txt`에 기록
+  현재 가상 환경에 설치된 패키지 목록을 `requirements.txt`에 기록  
+
+- `spark-submit /opt/spark/jobs/load_parquet_to_hdfs.py`  
+  Spark 잡을 실행하여 Parquet 데이터를 HDFS로 로드  
+
+- `spark-submit --master spark://spark-master:7077 /opt/spark/jobs/test_simple_job.py`  
+  Spark Master에서 `test_simple_job.py` 잡 실행  
+
+- `find / -name "spark_submit.py"`  
+  시스템에서 `spark_submit.py` 파일 검색  
+
+- `nano /home/airflow/.local/lib/python3.12/site-packages/airflow/providers/apache/spark/hooks/spark_submit.py`  
+  Airflow Spark Hook의 `spark_submit.py` 파일을 nano 에디터로 열기  
+
+- `sed -i '270s|conn_data\["master"\] = f"{conn.host}:{conn.port}"|conn_data["master"] = f"{conn.conn_type}://{conn.host}:{conn.port}"|' /home/airflow/.local/lib/python3.12/site-packages/airflow/providers/apache/spark/hooks/spark_submit.py`  
+  Airflow의 Spark Hook에서 특정 코드 수정  
+
+---
+
+## **리눅스 패키지 설치 명령어**  
+
+- `apt-get update -y`  
+  패키지 목록 업데이트  
+
+- `apt-get install -y nano`  
+  Nano 에디터 설치  
+
+- `apt-get install -y iputils-ping`  
+  `ping` 명령어를 포함하는 `iputils-ping` 패키지 설치  

--- a/documents/test-kafka-connect.md
+++ b/documents/test-kafka-connect.md
@@ -1,0 +1,92 @@
+# HDFS Sink를 이용한 Kafka Connect 테스트
+
+이 가이드는 HDFS Sink를 사용하여 Kafka Connect를 테스트하는 단계를 안내합니다. Docker를 사용하여 필요한 서비스를 설정하고, HDFS 권한을 구성하고, Kafka Connect 구성을 배포하고, 테스트 메시지를 생성합니다.
+
+## Kafka Connect 테스트 단계
+
+### 1. 필수 서비스 시작
+
+Docker Compose를 사용하여 Kafka, Zookeeper, HDFS (NameNode, DataNode) 및 Kafka Connect를 시작합니다.
+
+```sh
+docker compose up -d kafka zookeeper namenode datanode kafka-connect
+```
+
+### 2. HDFS 권한 설정
+
+Kafka Connect는 HDFS에 쓰기 위한 적절한 권한이 필요합니다. 다음 명령을 사용하여 권한을 설정합니다.
+
+```sh
+docker exec -it namenode bash
+```
+
+컨테이너 내부에서 다음을 실행합니다.
+
+```sh
+hdfs dfs -mkdir -p /user/appuser/test
+hdfs dfs -chown -R appuser:supergroup /user/appuser
+hdfs dfs -chmod -R 770 /user/appuser
+```
+
+컨테이너를 종료합니다.
+
+```sh
+exit
+```
+
+### 3. Kafka Connect HDFS Sink 배포
+
+HDFS Sink에 대한 Kafka Connect 구성을 제출합니다.
+
+```sh
+curl -X POST -H "Content-Type: application/json" --data @kafka/hdfs-sink-config/hdfs-sink-test.json http://localhost:8083/connectors
+```
+
+커넥터가 생성되었는지 확인합니다.
+
+```sh
+curl http://localhost:8083/connectors
+```
+
+### 4. 테스트 메시지 생성
+
+Kafka 컨테이너 쉘을 엽니다.
+
+```sh
+docker exec -it kafka bash
+```
+
+Kafka 콘솔 프로듀서를 시작합니다.
+
+```sh
+kafka-console-producer --broker-list kafka:9093 --topic test-topic
+```
+
+다음 JSON 메시지를 수동으로 입력합니다.
+
+```json
+{"id": 1, "name": "Alice"}
+{"id": 2, "name": "Bob"}
+{"id": 3, "name": "Charlie"}
+{"id": 4, "name": "David"}
+{"id": 5, "name": "Eve"}
+{"id": 6, "name": "Frank"}
+```
+
+**Ctrl+D**를 눌러 프로듀서를 종료합니다.
+
+### 5. HDFS에서 데이터 확인
+
+HDFS의 파일 목록을 표시합니다.
+
+```sh
+hdfs dfs -ls /user/appuser/test
+```
+
+생성된 파일의 내용을 확인합니다.
+
+```sh
+hdfs dfs -cat /user/appuser/test/<your-file>
+```
+
+`<your-file>`을 실제 파일 이름으로 바꿉니다.

--- a/flask/app.py
+++ b/flask/app.py
@@ -5,7 +5,8 @@ from kafka_producer import send_to_kafka, initialize_kafka_producer
 app = Flask(__name__)
 
 # Load Parquet data
-DATA_PATH = "../raw_data/neo-bank-non-sub-churn-prediction/test.parquet" 
+# DATA_PATH = "../raw_data/neo-bank-non-sub-churn-prediction/test.parquet" 
+DATA_PATH = "../raw_data/neo-bank-non-sub-churn-prediction/top_5000.parquet" 
 
 # Load data
 df = pd.read_parquet(DATA_PATH)

--- a/flask/app.py
+++ b/flask/app.py
@@ -58,6 +58,8 @@ def upload_data():
         
         # Filter data up to the selected date
         upload_df = df[df['date'] <= selected_date]
+        if latest_uploaded_date:
+            upload_df = upload_df[upload_df['date'] > latest_uploaded_date]
         
         # Send each row to Kafka
         for _, row in upload_df.iterrows():

--- a/flask/kafka_producer.py
+++ b/flask/kafka_producer.py
@@ -1,27 +1,83 @@
-from kafka import KafkaProducer
+from confluent_kafka import avro
+from confluent_kafka.avro import AvroProducer
 import json
-from datetime import date
+import numpy as np
+from datetime import date, datetime
 from kafka.errors import NoBrokersAvailable
 
 KAFKA_TOPIC = "neo_bank_data"
 KAFKA_BROKER = "kafka:9093"
 
 producer = None
+SCHEMA_REGISTRY_URL = "http://schema-registry:8082"
+
+# Avro 스키마 정의
+value_schema_str = """
+{
+   "type":"record",
+   "name":"Transaction",
+   "fields":[
+      {"name":"Id","type":"int"},
+      {"name":"customer_id","type":"int"},
+      {"name":"interest_rate","type":"float"},
+      {"name":"name","type":"string"},
+      {"name":"country","type":"string"},
+      {"name":"date_of_birth","type":"string"},
+      {"name":"address","type":"string"},
+      {"name":"date","type":"string"},
+      {"name":"atm_transfer_in","type":"int"},
+      {"name":"atm_transfer_out","type":"int"},
+      {"name":"bank_transfer_in","type":"int"},
+      {"name":"bank_transfer_out","type":"int"},
+      {"name":"crypto_in","type":"int"},
+      {"name":"crypto_out","type":"int"},
+      {"name":"bank_transfer_in_volume","type":"float"},
+      {"name":"bank_transfer_out_volume","type":"float"},
+      {"name":"crypto_in_volume","type":"float"},
+      {"name":"crypto_out_volume","type":"float"},
+      {"name":"complaints","type":"int"},
+      {"name":"touchpoints","type":{"type":"array","items":"string"}},
+      {"name":"csat_scores","type":"string"},
+      {"name":"tenure","type":"int"},
+      {"name":"from_competitor","type":"boolean"},
+      {"name":"job","type":"string"},
+      {"name":"churn_due_to_fraud","type":"boolean"},
+      {"name":"Usage","type":"string"},
+      {"name":"model_predicted_fraud","type":"boolean"}
+   ]
+}
+"""
+
+value_schema = avro.loads(value_schema_str)
 
 def initialize_kafka_producer():
     global producer
     try:
-        producer = KafkaProducer(
-            bootstrap_servers=KAFKA_BROKER,
-            value_serializer=lambda v: json.dumps(v, default=str).encode('utf-8')
+        producer = AvroProducer(
+            {'bootstrap.servers': KAFKA_BROKER,
+             'schema.registry.url': SCHEMA_REGISTRY_URL},
+            default_value_schema=value_schema
         )
         return True
     except NoBrokersAvailable:
         return False
 
-def send_to_kafka(data):
+def serialize_data(data):
+    # Convert datetime and date to string
+    for key, value in data.items():
+        if isinstance(value, (datetime, date)):
+            data[key] = value.isoformat()
+        elif isinstance(value, np.ndarray):
+            data[key] = value.tolist()  # Convert numpy arrays to lists
+        elif isinstance(value, dict):
+            data[key] = json.dumps(value)  # Convert dictionaries to JSON strings
+    return data
+
+def send_to_kafka(data, serialize=True):
     if producer is None:
         raise Exception("Kafka producer is not initialized")
-    data = {k: (v.isoformat() if isinstance(v, date) else v) for k, v in data.items()}
-    producer.send(KAFKA_TOPIC, data)
+
+    if serialize:
+        data = serialize_data(data) 
+    producer.produce(topic=KAFKA_TOPIC, value=data)
     producer.flush()

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -2,3 +2,4 @@ flask
 pandas
 kafka-python
 pyarrow
+confluent-kafka[avro]

--- a/kafka/hdfs-sink-config/hdfs-sink-test.json
+++ b/kafka/hdfs-sink-config/hdfs-sink-test.json
@@ -1,0 +1,19 @@
+{
+    "name": "hdfs-sink-test",
+    "config": {
+      "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
+      "tasks.max": "1",
+      "topics": "test-topic",
+      "hdfs.url": "hdfs://namenode:9000",
+      "flush.size": "3",
+      "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "value.converter.schemas.enable": "false",
+      "format.class": "io.confluent.connect.hdfs.json.JsonFormat",
+      "partitioner.class": "io.confluent.connect.storage.partitioner.DefaultPartitioner",
+      "storage.class": "io.confluent.connect.hdfs.storage.HdfsStorage",
+      "logs.dir": "/user/appuser/test/logs",
+      "topics.dir": "/user/appuser/test"
+    }
+  }
+  

--- a/kafka/hdfs-sink-config/hdfs-sink.json
+++ b/kafka/hdfs-sink-config/hdfs-sink.json
@@ -1,18 +1,19 @@
 {
   "name": "hdfs-sink",
   "config": {
-      "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
-      "tasks.max": "1",
-      "topics": "neo_bank_data",
-      "hdfs.url": "hdfs://namenode:9000",
-      "flush.size": "10",
-      "key.converter": "org.apache.kafka.connect.storage.StringConverter",
-      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-      "value.converter.schemas.enable": "false",
-      "format.class": "io.confluent.connect.hdfs.parquet.ParquetFormat",
-      "storage.class": "io.confluent.connect.hdfs.storage.HdfsStorage",
-      "logs.dir": "/user/appuser/neo_bank_data/logs",
-      "topics.dir": "/user/appuser/neo_bank_data",
-      "partitioner.class": "io.confluent.connect.storage.partitioner.DefaultPartitioner"
+    "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
+    "tasks.max": "1",
+    "topics": "neo_bank_data",
+    "hdfs.url": "hdfs://namenode:9000",
+    "flush.size": "100",
+    "format.class": "io.confluent.connect.hdfs.parquet.ParquetFormat",
+    "path.format": "/user/appuser/neo_bank_data",
+    "timestamp.extractor": "Record",
+    "topics.dir": "/user/appuser/neo_bank_data",
+    "logs.dir": "/user/appuser/neo_bank_data/logs",
+    "schema.compatibility": "NONE",
+    "value.converter": "io.confluent.connect.avro.AvroConverter",
+    "value.converter.schema.registry.url": "http://schema-registry:8082",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter"
   }
 }

--- a/kafka/hdfs-sink-config/hdfs-sink.json
+++ b/kafka/hdfs-sink-config/hdfs-sink.json
@@ -1,0 +1,18 @@
+{
+  "name": "hdfs-sink",
+  "config": {
+      "connector.class": "io.confluent.connect.hdfs.HdfsSinkConnector",
+      "tasks.max": "1",
+      "topics": "neo_bank_data",
+      "hdfs.url": "hdfs://namenode:9000",
+      "flush.size": "10",
+      "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "value.converter.schemas.enable": "false",
+      "format.class": "io.confluent.connect.hdfs.parquet.ParquetFormat",
+      "storage.class": "io.confluent.connect.hdfs.storage.HdfsStorage",
+      "logs.dir": "/user/appuser/neo_bank_data/logs",
+      "topics.dir": "/user/appuser/neo_bank_data",
+      "partitioner.class": "io.confluent.connect.storage.partitioner.DefaultPartitioner"
+  }
+}


### PR DESCRIPTION
This PR introduces several enhancements and fixes related to Kafka Connect, Avro Schema Registry, and HDFS Sink integration. Key updates include:  

### **New Features:**  
- **Kafka Connect Service & HDFS Sink Configuration**  
  - Added Kafka Connect to `docker-compose.yml` with required environment variables.  
  - Configured HDFS Sink Connector to automatically deploy on startup.  
  - Introduced `hdfs-sink.json` for HDFS Sink Connector setup.  

- **Schema Registry Integration**  
  - Added Schema Registry to `docker-compose.yml`.  
  - Updated Kafka Producer to use Avro serialization with Schema Registry.  
  - Configured Kafka Connect to use Avro Converter and Schema Registry.  
  - Updated HDFS Sink Connector to support Avro format.  

- **Airflow DAG for HDFS Data Verification**  
  - Added `read_parquet_sample` DAG to read and verify Parquet data in HDFS.  

### **Fixes & Improvements:**  
- Adjusted HDFS user directory creation logic to prevent incorrect path ownership.  
- Set replication factors for Kafka Connect storage topics to prevent topic creation failures.  
- Increased Kafka Connect startup delay for reliable connector deployment.  
- Ensured that only new data is sent to Kafka during uploads.  
- Switched to a smaller dataset (`top_5000.parquet`) to improve development efficiency.  

### **Documentation Updates:**  
- Updated command list documentation.  
- Added `test-kafka-connect.md` guide for Kafka Connect with HDFS Sink.  
